### PR TITLE
Allow to set a custom namespace per branch

### DIFF
--- a/kube-command.go
+++ b/kube-command.go
@@ -82,7 +82,7 @@ func kubeStartRollout() {
 	})
 
 	// Make sure first pod gets started
-	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, repoConfig.ReleaseName))
+	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), repoConfig.ReleaseName))
 
 	if !skipCanary {
 		// Pause to watch monitors and make sure that the 1 pod deploy was successful
@@ -99,7 +99,7 @@ func kubeStartRollout() {
 		thisDeployment = kubeapi.UpdateDeployment(repoConfig.ReleaseName, func(deployment *v1beta1.Deployment) {
 			deployment.Spec.Replicas = &desiredPods
 		})
-		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, repoConfig.ReleaseName))
+		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), repoConfig.ReleaseName))
 
 		if !skipCanary {
 			fmt.Println("\n=> Now, let's wait for 5 minutes, watch the monitors, and let everything simmer to make sure it looks good.")
@@ -116,7 +116,7 @@ func kubeStartRollout() {
 		mostRecentRelease = *kubeapi.UpdateDeployment(mostRecentRelease.Name, func(deployment *v1beta1.Deployment) {
 			deployment.Spec.Replicas = new(int32) // new() returns default value, which is 0 for int32
 		})
-		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, mostRecentRelease.Name))
+		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), mostRecentRelease.Name))
 
 		if !skipCanary {
 			fmt.Println("=> Now, let's wait for another 5 minutes, watch the monitors again, amd make sure we're confident with the new deployment.")
@@ -170,7 +170,7 @@ func safeBailOut(thisDeployment *v1beta1.Deployment, mostRecentRelease *v1beta1.
 			deployment.Labels["kubedeploy-is-live"] = "true"
 			delete(deployment.Labels, "kubedeploy-rollback-target")
 		})
-		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, mostRecentRelease.Name))
+		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), mostRecentRelease.Name))
 
 		fmt.Println("=> Deleting the deployment we created...")
 		kubeapi.DeleteDeployment(thisDeployment)
@@ -200,7 +200,7 @@ func kubeRollingRestart() {
 	kubeapi.UpdateDeployment(isLive.Name, func(deployment *v1beta1.Deployment) {
 		deployment.Spec.Template.Labels["kubedeploy-last-rolling-restart"] = strconv.FormatInt(time.Now().Unix(), 10)
 	})
-	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, isLive.Name))
+	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), isLive.Name))
 
 	fmt.Printf("\n=> All pods have been recreated.\n\n")
 }
@@ -236,7 +236,7 @@ func kubeInstantRollback() {
 		deployment.Labels["kubedeploy-is-live"] = "true"
 		delete(deployment.Labels, "kubedeploy-rollback-target")
 	})
-	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, rollbackTarget.Name))
+	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), rollbackTarget.Name))
 
 	if !runFlags.Bool("force") && !runFlags.Bool("no-canary") {
 		fmt.Println("\n=> Wait for one minute to make sure that the old pods came up correctly.")
@@ -251,7 +251,7 @@ func kubeInstantRollback() {
 	})
 
 	fmt.Println("=> Wait for the old pods to scale down to 0.")
-	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, rollbackTarget.Name))
+	cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), rollbackTarget.Name))
 
 	fmt.Printf("=> The deployment has been successfully rolled back to: %s.\n", rollbackTarget.Name)
 }
@@ -265,7 +265,7 @@ func kubeScaleDeployment(replicas int32) {
 		kubeapi.UpdateDeployment(liveDeployment.Name, func(deployment *v1beta1.Deployment) {
 			deployment.Spec.Replicas = &replicas
 		})
-		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.Namespace, repoConfig.ReleaseName))
+		cli.StreamAndGetCommandOutputAndExitCode("kubectl", fmt.Sprintf("rollout status --namespace=%s deployment/%s", repoConfig.EnvVarsMap.GetNameSpace(), repoConfig.ReleaseName))
 		fmt.Printf("=> Finished scaling to %d replica(s).\n", replicas)
 	} else {
 		fmt.Println("=> Whoah, there's more than one 'is_live' deployment. You should fix that first.")

--- a/kube-template.go
+++ b/kube-template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/mycujoo/kube-deploy/cli"
 	"io/ioutil"
+	"log"
 	"os"
 	"strings"
 )
@@ -14,8 +15,7 @@ func kubeMakeTemplates() []string {
 
 	templateFiles, err := ioutil.ReadDir(repoConfig.Application.PathToKubernetesFiles)
 	if err != nil {
-		fmt.Println("=> Unable to get list of kubernetes files.")
-		os.Exit(1)
+		log.Fatal("=> Unable to get list of kubernetes files.")
 	}
 
 	var filePaths []string
@@ -69,8 +69,7 @@ func runConsulTemplate(filename string) string {
 
 	output, exitCode := cli.GetCommandOutputAndExitCode("consul-template", consulTemplateArgs)
 	if exitCode != 0 {
-		fmt.Println("=> Oh no, looks like consul-template failed!")
-		os.Exit(1)
+		log.Fatal("=> Oh no, looks like consul-template failed!")
 	}
 
 	return strings.Join(strings.Split(output, "\n")[1:], "\n")

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 
 => That means we're dealing with the image tag:
 	%s
-`, repoConfig.DockerRepository.RegistryRoot, repoConfig.Application.Name, repoConfig.GitBranch, repoConfig.GitSHA, repoConfig.Namespace, repoConfig.ImageFullPath)
+`, repoConfig.DockerRepository.RegistryRoot, repoConfig.Application.Name, repoConfig.GitBranch, repoConfig.GitSHA, repoConfig.EnvVarsMap.GetNameSpace(), repoConfig.ImageFullPath)
 	}
 
 	// args has to have at least length 2, since the first element is the executable name
@@ -64,7 +64,7 @@ func main() {
 		case "name":
 			fmt.Fprintln(osstdout, repoConfig.ImageFullPath)
 		case "environment":
-			fmt.Fprintln(osstdout, repoConfig.Namespace)
+			fmt.Fprintln(osstdout, repoConfig.EnvVarsMap.GetNameSpace())
 		case "cluster":
 			fmt.Fprintln(osstdout, repoConfig.ClusterName)
 		case "release":

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"io/ioutil"
+	"log"
 	"strconv"
 	"strings"
 
@@ -36,8 +37,7 @@ func main() {
 	// TODO: for some reason, on a linux machine, if any command other than 'curl' is executed first, all
 	//		 subcommands fail - but sometimes, the first-run after 'go build' works. Who knows...
 	if exitCode := cli.GetCommandExitCode("curl", "-s --connect-timeout 3 https://google.com"); exitCode != 0 {
-		fmt.Println("=> Uh oh, looks like you're not connected to the internet (or maybe it's just too slow).")
-		os.Exit(1)
+		log.Fatal("=> Uh oh, looks like you're not connected to the internet (or maybe it's just too slow).")
 	}
 
 	if !runFlags.Bool("test-only") {
@@ -133,15 +133,13 @@ func main() {
 				fmt.Print("=> Press 'y' to show the help menu, anything else to exit.\n>>>  ")
 				pleaseHelpMe, _ := reader.ReadString('\n')
 				if pleaseHelpMe != "y\n" && pleaseHelpMe != "Y\n" {
-					fmt.Println("Better luck next time.")
-					os.Exit(0)
+					log.Fatal("Better luck next time.")
 				}
 				showHelp()
 			}
 		}
 	} else {
-		fmt.Println("You'll need to add a command.")
-		os.Exit(0)
+		log.Fatal("You'll need to add a command.")
 	}
 }
 
@@ -179,9 +177,8 @@ func parseFlags() {
 	runFlags.NewBoolFlag("quiet", "q", "Silences as much output as possible.")
 	runFlags.NewBoolFlag("keep-kubernetes-template-files", "", "Leaves the templated-out kubernetes files under the directory '.kubedeploy-temp'.")
 	if err := runFlags.Parse(os.Args...); err != nil {
-		fmt.Println("\n=> Oh no, I don't know what to do with those command line flags. Sorry...")
-		fmt.Println(runFlags.ShowUsage(4))
-		os.Exit(1)
+		log.Println("\n=> Oh no, I don't know what to do with those command line flags. Sorry...")
+		log.Fatal(runFlags.ShowUsage(4))
 	}
 	args = runFlags.Args()
 }

--- a/main.go
+++ b/main.go
@@ -5,9 +5,11 @@ import (
 	"io/ioutil"
 	"strconv"
 	"strings"
+
 	// "flag"
 	"fmt"
 	"os"
+
 	// "os/user"
 	"github.com/mycujoo/kube-deploy/build"
 	"github.com/mycujoo/kube-deploy/cli"
@@ -46,10 +48,11 @@ func main() {
 	Repository name: %s
 	Current branch: %s
 	HEAD hash: %s
-			
+	Namespace: %s
+
 => That means we're dealing with the image tag:
 	%s
-`, repoConfig.DockerRepository.RegistryRoot, repoConfig.Application.Name, repoConfig.GitBranch, repoConfig.GitSHA, repoConfig.ImageFullPath)
+`, repoConfig.DockerRepository.RegistryRoot, repoConfig.Application.Name, repoConfig.GitBranch, repoConfig.GitSHA, repoConfig.Namespace, repoConfig.ImageFullPath)
 	}
 
 	// args has to have at least length 2, since the first element is the executable name


### PR DESCRIPTION
This PR is to adress the following issue:

```
=> Generating YAML from template for deploy.yaml
	|  deployment "vertx-kafka-client-1.0.0-development-5719c9e" created
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xec4eb7]

goroutine 1 [running]:
main.kubeStartRollout()
	/Users/radev/go/src/github.com/mycujoo/kube-deploy/kube-command.go:71 +0x6a7
main.main()
	/Users/radev/go/src/github.com/mycujoo/kube-deploy/main.go:94 +0xecd
Exited with code 2
```

You can specify a custom namespace in deploy.yaml and it will be templated correctly but kube-deploy itself only looks for the deployment in the default namespaces. This PR addresses that issue.